### PR TITLE
The box belongs to the place

### DIFF
--- a/docs/implementation.org
+++ b/docs/implementation.org
@@ -102,10 +102,18 @@ the buffer prefixes itself — the =line-prefix= on the text or on an
 overlay that is not the box's, whatever it holds — and
 =window-box--compose= hangs one overlay per region carrying the side
 and that region's own prefix concatenated, the side alone where the
-own one is no string, at =priority 101=, above any overlay of the
-buffer's.  Where two of those overlap the narrower wins: measured, an
-overlay inside another of the same priority answers for the lines they
-share, so a subtree inside a subtree keeps the deeper guide.
+own one is no string, above any overlay of the buffer's.  Where two of
+those overlap the narrower wins: measured, an overlay inside another of
+the same priority answers for the lines they share, so a subtree inside
+a subtree keeps the deeper guide.
+
+That tie is why a region carrying a prefix sits at =priority 102= and
+one carrying nothing at =101=.  dirvish leaves a number on every line
+of an open subtree — bookkeeping, and a =line-prefix= of a number draws
+no prefix at all — beside the overlay whose guide spans the whole
+subtree.  Both are composed, and on one priority the narrower answers:
+the number is one line and the guide is the subtree, so the guide lost
+and every folder inside a folder stood unindented.
 
 There was a whole-buffer overlay under those, at =priority 100=, and a
 cap on the regions composed, sixty-four; past the cap the box shed the

--- a/test/window-box-test.el
+++ b/test/window-box-test.el
@@ -1071,7 +1071,10 @@ other row is passed through by the sides."
 A bitmap repeats over every line's full height, however tall the
 line; a margin image is one default line tall and dashed on taller
 ones, and one taller than the line grows every line to its height."
-  (skip-unless (fboundp 'define-fringe-bitmap))
+  ;; A build without fringes still has `define-fringe-bitmap': fringe.el
+  ;; defines one that defines nothing.  Whether a standard bitmap is
+  ;; there says whether one can be made at all.
+  (skip-unless (fringe-bitmap-p 'left-arrow))
   (let* ((window (selected-window))
          (prefix (cl-letf (((symbol-function 'display-graphic-p)
                             (lambda (&rest _) t)))
@@ -1094,7 +1097,10 @@ missing in every window whose right fringe was narrower — a window
 the old eight pixel bitmap drew at a fringe of eight and at no width
 below it, and a bitmap of the fringe's own width drew at eight, four,
 two and one."
-  (skip-unless (fboundp 'define-fringe-bitmap))
+  ;; A build without fringes still has `define-fringe-bitmap': fringe.el
+  ;; defines one that defines nothing.  Whether a standard bitmap is
+  ;; there says whether one can be made at all.
+  (skip-unless (fringe-bitmap-p 'left-arrow))
   ;; One name per side and width, and the name says which.
   (should (eq (window-box--side-bitmap 'right 1) 'window-box--right-side-1))
   (should (eq (window-box--side-bitmap 'left 8) 'window-box--left-side-8))

--- a/test/window-box-test.el
+++ b/test/window-box-test.el
@@ -137,6 +137,34 @@ its indentation."
       (should-not (window-box--composed))
       (should (equal (get-char-property (point-min) 'line-prefix) "| ")))))
 
+(ert-deftest window-box-test-a-guide-wins-over-the-bookkeeping-beside-it ()
+  "A line that carries a guide and a number keeps the guide.
+dirvish leaves a number as `line-prefix' on every line of an open
+subtree — bookkeeping, and a number draws no prefix at all — beside the
+overlay whose guide spans the whole subtree.  Both are composed, and
+Emacs settles a tie between overlays of one priority on the narrower
+one: the number is a line and the guide is the subtree, so the guide
+lost and every folder inside a folder stood unindented."
+  (window-box-test--with-buffer
+    (goto-char (point-min))
+    (let* ((second (line-beginning-position 2))
+           (guide (make-overlay (point-min) (point-max)))
+           (number (make-overlay second (line-end-position 2))))
+      (overlay-put guide 'line-prefix " │")
+      (overlay-put number 'line-prefix 2)
+      (window-box-mode 1)
+      (let ((shown (get-char-property second 'line-prefix)))
+        (should (stringp shown))
+        ;; the sides, and the guide after them
+        (should (string-suffix-p " │" shown))
+        (should (> (length shown) 2)))
+      ;; the line with the number alone still wears the sides
+      (let ((only (make-overlay (point-min) (line-end-position 1))))
+        (delete-overlay guide)
+        (overlay-put only 'line-prefix 1)
+        (window-box--compose)
+        (should (stringp (get-char-property (point-min) 'line-prefix)))))))
+
 (ert-deftest window-box-test-a-growing-gutter-keeps-its-sides ()
   "A buffer that prefixes every line it prints keeps the sides.
 An agent's shell indents each line of an answer with a `line-prefix' of

--- a/window-box.el
+++ b/window-box.el
@@ -59,6 +59,7 @@
 ;;; Code:
 
 (require 'face-remap)
+(require 'fringe)
 (require 'seq)
 
 (defgroup window-box nil

--- a/window-box.el
+++ b/window-box.el
@@ -694,11 +694,20 @@ in five milliseconds."
     (widen)
     (mapc #'delete-overlay (window-box--composed))
     (pcase-dolist (`(,beg ,end ,own) (window-box--own-prefixes))
-      (let* ((own (if (stringp own) own ""))
+      (let* ((carries (stringp own))
+             (own (if carries own ""))
              (ov (make-overlay beg end))
              (both (concat line-prefix own)))
         (overlay-put ov 'window-box--own own)
-        (overlay-put ov 'priority 101)
+        ;; A region that carries something goes above one that carries
+        ;; nothing.  dirvish leaves a number on every line of an open
+        ;; subtree — bookkeeping, and a `line-prefix' of a number draws
+        ;; no prefix at all — beside the overlay whose guide spans the
+        ;; whole subtree.  Both are composed, and Emacs settles a tie
+        ;; between overlays of one priority on the narrower: the number
+        ;; is one line and the guide is the subtree, so the guide lost
+        ;; and every folder inside a folder stood unindented.
+        (overlay-put ov 'priority (if carries 102 101))
         (overlay-put ov 'line-prefix both)
         (overlay-put ov 'wrap-prefix both)))))
 


### PR DESCRIPTION
Eight commits on dev since main.

- feat: global-window-box-mode boxes every window the predicate accepts, whatever buffer it shows; a buffer that leaves a boxed window is undressed at the next refresh. dirvish puts a new listing into its side window without display-buffer, and a per-buffer mode set from a display hook left that panel bare.
- fix: new gutter wears its sides when the command ends, from a buffer-local post-command-hook; the idle timer stays for process output.
- fix: a subtree keeps its guide beside the box (overlay priority).
- fix: the compiler knows fringe-bitmap-p again, and a build without fringes skips the bitmap tests.
- refactor: the review of the whole file — the prefix reads its margin off the window, one-caller helpers folded, one meaning per word for own, shorter hook setup, docstrings that say what the code does (a face remap does not color the box; window-box-color does).
- docs: the notes carry the priority a guide needs; the implementation notes follow every change.

Checks: make (compile, lint, relint, 54 tests), make tty, make gui, and the dirvish side flows in the configuration on the rig, GUI and terminal.

Not included: the version bump to 1.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)